### PR TITLE
Complete sales report form and endpoint

### DIFF
--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,6 +1,6 @@
 // src/lib/http.ts
 
-const API_BASE_URL = 'http://192.168.11.115:3001/api';
+const API_BASE_URL = `${import.meta.env.VITE_API_URL || 'http://localhost:3001'}/api`;
 
 /**
  * ساخت هدر برای درخواست‌ها


### PR DESCRIPTION
## Summary
- update HTTP helper to use env base URL
- send sales report as JSON and reset form on close
- add `/api/sales/reports` alias route on the backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68835477aed48329a5127298102097f9